### PR TITLE
feat(authz): bypass authorization for users.admins entitlement group

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,5 +69,6 @@ jobs:
         with:
           tag_name: ${{ steps.meta.outputs.VERSION }}
           name: Release ${{ steps.meta.outputs.VERSION }}
+          generate_release_notes: true
           draft: false
           prerelease: false

--- a/internal/fakes/config.go
+++ b/internal/fakes/config.go
@@ -1,6 +1,9 @@
 package fakes
 
 import (
+	"context"
+	"time"
+
 	"github.com/allegro/bigcache/v3"
 	"github.com/google/uuid"
 )
@@ -45,6 +48,13 @@ func (c *MockConfig) Version() string {
 }
 
 func NewConfig(d, sg, n, v string, pid uuid.UUID, mb int16) *MockConfig {
+	cache, _ := bigcache.New(context.Background(), bigcache.Config{
+		Shards:             1,
+		LifeWindow:         5 * time.Minute,
+		MaxEntriesInWindow: 100,
+		MaxEntrySize:       500,
+		HardMaxCacheSize:   8,
+	})
 	return &MockConfig{
 		domain:        d,
 		serviceGroup:  sg,
@@ -52,5 +62,6 @@ func NewConfig(d, sg, n, v string, pid uuid.UUID, mb int16) *MockConfig {
 		version:       v,
 		productID:     pid,
 		memoryLimitMB: mb,
+		apiCache:      cache,
 	}
 }

--- a/middleware/authorization.go
+++ b/middleware/authorization.go
@@ -48,13 +48,12 @@ func AuthorizationMiddleware(cfg interfaces.Config, logger interfaces.Logger, ro
 
 			}
 
-			// Use the user information from the claims (e.g., Sub or Rol)
 			userID := claims.Sub
 
 			entry, err := cfg.APICache().Get(userID)
 			if err == nil {
 				logger.Info(ctx, "Cache entry for user: %s", userID)
-				if userIsMember(ctx, logger, entry, roles) {
+				if isAdmin(ctx, logger, entry) || hasAccess(ctx, logger, entry, roles) {
 					logger.Info(ctx, "Entitlement accepts request for user: %s", userID)
 					return next(c)
 				}
@@ -88,13 +87,12 @@ func AuthorizationMiddleware(cfg interfaces.Config, logger interfaces.Logger, ro
 				return errorHandler(c, &cfg, http.StatusUnauthorized, "Entitlements refused request", nil, logger, producer, "authz.denied", claims, topic)
 			}
 
-			// Cache result
 			err = cfg.APICache().Set(userID, body)
 			if err != nil {
 				logger.Error(ctx, "failed to set %s in cache", userID)
 			}
 
-			if !userIsMember(ctx, logger, body, roles) {
+			if !isAdmin(ctx, logger, body) && !hasAccess(ctx, logger, body, roles) {
 				return errorHandler(c, &cfg, http.StatusForbidden, "Permission denied", nil, logger, producer, "authz.denied", claims, topic)
 			}
 
@@ -104,33 +102,39 @@ func AuthorizationMiddleware(cfg interfaces.Config, logger interfaces.Logger, ro
 	}
 }
 
-// Function asserting if target group is one of the groups
-// user has a membership in.
-func userIsMember(ctx context.Context, logger interfaces.Logger, responseBody []byte, namesToMatch []string) bool {
-	var entitlements []entitlement.Entitlement
-
-	// Unmarshal the JSON response into a slice of ApiResponse
-	err := json.Unmarshal(responseBody, &entitlements)
-	if err != nil {
-		logger.Error(ctx, "Failed to unmarshal API response: %v", err)
+// isAdmin returns true when the entitlements response contains the "admin" group.
+func isAdmin(ctx context.Context, logger interfaces.Logger, responseBody []byte) bool {
+	var groups []entitlement.Entitlement
+	if err := json.Unmarshal(responseBody, &groups); err != nil {
+		logger.Error(ctx, "Failed to unmarshal entitlements response: %v", err)
 		return false
 	}
-
-	// Create a map for quick lookup of names to match
-	nameSet := make(map[string]bool)
-	for _, name := range namesToMatch {
-		nameSet[name] = true
-	}
-
-	// Check if any of the names match in the response
-	for _, item := range entitlements {
-		if _, exists := nameSet[item.Name]; exists {
-			logger.Info(ctx, "Match found for name: %s", item.Name)
-			return true // Return true as soon as a match is found
+	for _, g := range groups {
+		if g.Name == "users.admins" {
+			logger.Info(ctx, "Admin group membership grants access")
+			return true
 		}
 	}
+	return false
+}
 
-	// Return false if no match was found
+// hasAccess returns true when the entitlements response contains any of the required roles.
+func hasAccess(ctx context.Context, logger interfaces.Logger, responseBody []byte, roles []string) bool {
+	var groups []entitlement.Entitlement
+	if err := json.Unmarshal(responseBody, &groups); err != nil {
+		logger.Error(ctx, "Failed to unmarshal entitlements response: %v", err)
+		return false
+	}
+	allowed := make(map[string]bool, len(roles))
+	for _, r := range roles {
+		allowed[r] = true
+	}
+	for _, g := range groups {
+		if allowed[g.Name] {
+			logger.Info(ctx, "Match found for name: %s", g.Name)
+			return true
+		}
+	}
 	return false
 }
 

--- a/middleware/authorization.go
+++ b/middleware/authorization.go
@@ -20,6 +20,8 @@ import (
 	"github.com/grasp-labs/ds-go-echo-middleware/v2/middleware/requestctx"
 )
 
+const adminGroup = "users.admins"
+
 // AuthorizationMiddleware for asserting a user is permitted
 // to perform action.
 func AuthorizationMiddleware(cfg interfaces.Config, logger interfaces.Logger, roles []string, url string, producer *adapters.ProducerAdapter, topic string) echo.MiddlewareFunc {
@@ -51,9 +53,11 @@ func AuthorizationMiddleware(cfg interfaces.Config, logger interfaces.Logger, ro
 			userID := claims.Sub
 
 			entry, err := cfg.APICache().Get(userID)
-			if err == nil {
+			if err != nil {
+				logger.Info(ctx, "Cache miss for user %s: %v", userID, err)
+			} else {
 				logger.Info(ctx, "Cache entry for user: %s", userID)
-				if isAdmin(ctx, logger, entry) || hasAccess(ctx, logger, entry, roles) {
+				if isGranted(ctx, logger, entry, roles) {
 					logger.Info(ctx, "Entitlement accepts request for user: %s", userID)
 					return next(c)
 				}
@@ -87,12 +91,13 @@ func AuthorizationMiddleware(cfg interfaces.Config, logger interfaces.Logger, ro
 				return errorHandler(c, &cfg, http.StatusUnauthorized, "Entitlements refused request", nil, logger, producer, "authz.denied", claims, topic)
 			}
 
+			// Cache result
 			err = cfg.APICache().Set(userID, body)
 			if err != nil {
 				logger.Error(ctx, "failed to set %s in cache", userID)
 			}
 
-			if !isAdmin(ctx, logger, body) && !hasAccess(ctx, logger, body, roles) {
+			if !isGranted(ctx, logger, body, roles) {
 				return errorHandler(c, &cfg, http.StatusForbidden, "Permission denied", nil, logger, producer, "authz.denied", claims, topic)
 			}
 
@@ -102,33 +107,22 @@ func AuthorizationMiddleware(cfg interfaces.Config, logger interfaces.Logger, ro
 	}
 }
 
-// isAdmin returns true when the entitlements response contains the "admin" group.
-func isAdmin(ctx context.Context, logger interfaces.Logger, responseBody []byte) bool {
+// isGranted returns true when the entitlements response grants access — either
+// because the user is a member of "users.admins" or of one of the required roles.
+// Parses the response body once and checks both conditions in a single pass.
+func isGranted(ctx context.Context, logger interfaces.Logger, responseBody []byte, roles []string) bool {
 	var groups []entitlement.Entitlement
 	if err := json.Unmarshal(responseBody, &groups); err != nil {
 		logger.Error(ctx, "Failed to unmarshal entitlements response: %v", err)
 		return false
 	}
-	for _, g := range groups {
-		if g.Name == "users.admins" {
-			logger.Info(ctx, "Admin group membership grants access")
-			return true
-		}
-	}
-	return false
-}
 
-// hasAccess returns true when the entitlements response contains any of the required roles.
-func hasAccess(ctx context.Context, logger interfaces.Logger, responseBody []byte, roles []string) bool {
-	var groups []entitlement.Entitlement
-	if err := json.Unmarshal(responseBody, &groups); err != nil {
-		logger.Error(ctx, "Failed to unmarshal entitlements response: %v", err)
-		return false
-	}
-	allowed := make(map[string]bool, len(roles))
+	allowed := make(map[string]bool, len(roles)+1)
+	allowed[adminGroup] = true
 	for _, r := range roles {
 		allowed[r] = true
 	}
+
 	for _, g := range groups {
 		if allowed[g.Name] {
 			logger.Info(ctx, "Match found for name: %s", g.Name)

--- a/middleware/authorization_test.go
+++ b/middleware/authorization_test.go
@@ -1,0 +1,203 @@
+package middleware_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grasp-labs/ds-go-echo-middleware/v2/internal/fakes"
+	"github.com/grasp-labs/ds-go-echo-middleware/v2/middleware"
+	"github.com/grasp-labs/ds-go-echo-middleware/v2/middleware/adapters"
+	"github.com/grasp-labs/ds-go-echo-middleware/v2/middleware/claims"
+)
+
+func newAuthzTestClaims() *claims.Context {
+	return &claims.Context{
+		Sub: "test-user@example.com",
+		Jti: uuid.New(),
+		Rsc: uuid.New().String() + ":test-tenant",
+	}
+}
+
+func newAuthzEcho(t *testing.T, userClaims *claims.Context, entitlementsURL string) *echo.Echo {
+	t.Helper()
+	e := echo.New()
+
+	cfg := fakes.NewConfig("dp", "core", "test-svc", "v0.0.1", uuid.New(), 512)
+	logger := &fakes.MockLogger{}
+	producer := &adapters.ProducerAdapter{Producer: &fakes.MockProducer{}}
+	topic := "ds.test.authz.v1"
+
+	e.Use(injectContext(userClaims))
+	e.Use(middleware.AuthorizationMiddleware(cfg, logger, []string{"required-group"}, entitlementsURL, producer, topic))
+	e.GET("/protected/", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
+	return e
+}
+
+// injectContext returns a middleware that plants userContext and Authorization
+// into the Echo context, mimicking what the authentication middleware does.
+func injectContext(userClaims *claims.Context) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			c.Set("userContext", userClaims)
+			c.Set("Authorization", "Bearer fake-token")
+			return next(c)
+		}
+	}
+}
+
+// mockEntitlementsServer spins up a test HTTP server that returns the given
+// groups as an entitlements response.
+func mockEntitlementsServer(t *testing.T, groups []string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		payload := make([]map[string]any, len(groups))
+		for i, g := range groups {
+			payload[i] = map[string]any{
+				"id":        uuid.New().String(),
+				"name":      g,
+				"tenant_id": uuid.New().String(),
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+}
+
+// --- Bypass tests ---
+
+// TestAuthorizationMiddleware_AdminGroupBypass verifies that a user who is a
+// member of the "admin" entitlements group is allowed through regardless of
+// the required roles configured on the middleware.
+func TestAuthorizationMiddleware_AdminGroupBypass(t *testing.T) {
+	entitlementsCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		entitlementsCalled = true
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"id": uuid.New().String(), "name": "users.admins", "tenant_id": uuid.New().String()},
+		})
+	}))
+	defer srv.Close()
+
+	// Required role is "required-group"; user is only in "admin" — bypass should fire.
+	e := newAuthzEcho(t, newAuthzTestClaims(), srv.URL+"/groups/")
+
+	req := httptest.NewRequest(http.MethodGet, "/protected/", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, entitlementsCalled, "entitlements must still be called to discover admin membership")
+}
+
+// --- Normal-path tests (entitlements called) ---
+
+// TestAuthorizationMiddleware_RegularRoleCallsEntitlements confirms that a JWT
+// without "root" goes through the entitlements graph check and is granted
+// access when the entitlements service returns a matching group.
+func TestAuthorizationMiddleware_RegularRoleCallsEntitlements(t *testing.T) {
+	entitlementsCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		entitlementsCalled = true
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"id": uuid.New().String(), "name": "required-group", "tenant_id": uuid.New().String()},
+		})
+	}))
+	defer srv.Close()
+
+	e := newAuthzEcho(t, newAuthzTestClaims(), srv.URL+"/groups/")
+
+	req := httptest.NewRequest(http.MethodGet, "/protected/", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, entitlementsCalled, "entitlements service must be called for non-bypass roles")
+}
+
+// TestAuthorizationMiddleware_NonBypassRoleNotInGroup confirms that a non-bypass
+// JWT whose subject is absent from the required entitlements group is denied.
+func TestAuthorizationMiddleware_NonBypassRoleNotInGroup(t *testing.T) {
+	srv := mockEntitlementsServer(t, []string{"some-other-group"})
+	defer srv.Close()
+
+	e := newAuthzEcho(t, newAuthzTestClaims(), srv.URL+"/groups/")
+
+	req := httptest.NewRequest(http.MethodGet, "/protected/", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// TestAuthorizationMiddleware_EmptyRolesArray guards against an accidental
+// "empty rol claim = bypass" regression: an empty Rol slice must still fall
+// through to the entitlements check and be denied if not in the group.
+func TestAuthorizationMiddleware_EmptyRolesArray(t *testing.T) {
+	entitlementsCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		entitlementsCalled = true
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode([]map[string]any{})
+	}))
+	defer srv.Close()
+
+	e := newAuthzEcho(t, newAuthzTestClaims(), srv.URL+"/groups/")
+
+	req := httptest.NewRequest(http.MethodGet, "/protected/", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.True(t, entitlementsCalled, "entitlements must still be called when Rol is empty")
+}
+
+// TestAuthorizationMiddleware_EntitlementsReturnsError confirms fail-closed
+// behaviour: when the entitlements service returns a 5xx, the middleware denies
+// the request rather than allowing it through.
+func TestAuthorizationMiddleware_EntitlementsReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	e := newAuthzEcho(t, newAuthzTestClaims(), srv.URL+"/groups/")
+
+	req := httptest.NewRequest(http.MethodGet, "/protected/", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// --- Infrastructure tests ---
+
+// TestAuthorizationMiddleware_MissingUserContext checks that a missing user
+// context is denied (errorHandler always returns echo.ErrForbidden).
+func TestAuthorizationMiddleware_MissingUserContext(t *testing.T) {
+	e := echo.New()
+	cfg := fakes.NewConfig("dp", "core", "test-svc", "v0.0.1", uuid.New(), 512)
+	logger := &fakes.MockLogger{}
+	producer := &adapters.ProducerAdapter{Producer: &fakes.MockProducer{}}
+	topic := "ds.test.authz.v1"
+
+	e.Use(middleware.AuthorizationMiddleware(cfg, logger, []string{"required-group"}, "http://unused/", producer, topic))
+	e.GET("/protected/", func(c echo.Context) error { return c.NoContent(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodGet, "/protected/", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}


### PR DESCRIPTION
## Summary

- Users in the `users.admins` entitlements group are granted access without checking required roles (`isAdmin` bypass)
- Required-role membership check extracted into `hasAccess` for clarity
- Release workflow updated to auto-generate release notes on GitHub releases

## Test plan

- [ ] `TestAuthorizationMiddleware_AdminGroupBypass` — `users.admins` member bypasses required-role check → 200
- [ ] `TestAuthorizationMiddleware_RegularRoleCallsEntitlements` — non-admin user with matching group → 200
- [ ] `TestAuthorizationMiddleware_NonBypassRoleNotInGroup` — non-admin user not in required group → 403
- [ ] `TestAuthorizationMiddleware_EmptyRolesArray` — empty entitlements → 403, entitlements still called
- [ ] `TestAuthorizationMiddleware_EntitlementsReturnsError` — entitlements 5xx → 403 (fail-closed)
- [ ] `TestAuthorizationMiddleware_MissingUserContext` — no user context → 403