### PR TITLE
fix: send Kafka events asynchronously to avoid blocking HTTP responses

### DIFF
--- a/internal/fakes/producer.go
+++ b/internal/fakes/producer.go
@@ -1,25 +1,70 @@
 package fakes
 
-import "context"
+import (
+	"context"
+	"sync"
+	"time"
+)
 
-// --- Mock Producer ---
+// MockProducer is a thread-safe test double for adapters.Producer.
+// Call WaitForSend before asserting Called()/Value() in tests that use
+// sendEventAsync, since the real Send now runs in a goroutine.
 type MockProducer struct {
+	mu    sync.Mutex
+	once  sync.Once
+	ready chan struct{}
+
 	called bool
 	key    string
 	value  any
 }
 
-func (m *MockProducer) Called() bool { return m.called }
-func (m *MockProducer) Key() string  { return m.key }
-func (m *MockProducer) Value() any   { return m.value }
-
-func (p *MockProducer) Close() error {
-	return nil
+func (m *MockProducer) ch() chan struct{} {
+	m.once.Do(func() { m.ready = make(chan struct{}, 1) })
+	return m.ready
 }
 
+// WaitForSend blocks until Send is called or the timeout elapses.
+// Returns true if Send was (or had already been) called.
+func (m *MockProducer) WaitForSend(timeout time.Duration) bool {
+	select {
+	case <-m.ch():
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+func (m *MockProducer) Called() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.called
+}
+
+func (m *MockProducer) Key() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.key
+}
+
+func (m *MockProducer) Value() any {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.value
+}
+
+func (m *MockProducer) Close() error { return nil }
+
 func (m *MockProducer) Send(ctx context.Context, key string, value any) error {
+	m.mu.Lock()
 	m.called = true
 	m.key = key
 	m.value = value
+	m.mu.Unlock()
+
+	select {
+	case m.ch() <- struct{}{}:
+	default:
+	}
 	return nil
 }

--- a/middleware/audit.go
+++ b/middleware/audit.go
@@ -146,10 +146,7 @@ func AuditMiddleware(cfg interfaces.Config, logger interfaces.Logger, producer *
 				},
 			}
 
-			kafkaErr := producer.Send(c.Request().Context(), topic, event)
-			if kafkaErr != nil {
-				logger.Error(c.Request().Context(), "Failed to send %s event to Kafka topic '%s' for event ID %s: %v", "audit.log", topic, event.Id.String(), kafkaErr)
-			}
+			sendEventAsync(producer, logger, topic, event, "audit.log")
 
 			return callErr
 		}

--- a/middleware/audit_test.go
+++ b/middleware/audit_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
@@ -62,6 +63,7 @@ func TestAuditMiddleware_BasicFlow(t *testing.T) {
 
 	// Assertions
 	assert.Equal(t, http.StatusCreated, rec.Code)
+	assert.True(t, mock.WaitForSend(time.Second), "Producer should have been called within 1s")
 	assert.True(t, mock.Called(), "Producer should have been called")
 	assert.NotEmpty(t, mock.Key(), "Audit key (request ID) should be set")
 
@@ -140,6 +142,7 @@ func TestAuditMiddleware_NonJSON_DoesNotDrainBody(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	// Producer should have been called even for non-JSON
+	assert.True(t, mp.WaitForSend(time.Second), "Producer should have been called within 1s")
 	if !assert.True(t, mp.Called(), "Producer should have been called for non-JSON too") {
 		t.Fatalf("producer not called; check GetTenantId() expectations and userContext fixture")
 	}
@@ -195,6 +198,7 @@ func TestAuditMiddleware_SuccessResponse_NoResponseBody(t *testing.T) {
 	e.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusCreated, rec.Code)
+	assert.True(t, mock.WaitForSend(time.Second), "Producer should have been called within 1s")
 	assert.True(t, mock.Called(), "Producer should have been called")
 
 	eventJson, ok := mock.Value().(sdkmodels.EventJson)
@@ -268,6 +272,7 @@ func TestAuditMiddleware_ErrorResponse_CapturesResponseBody(t *testing.T) {
 	assert.Equal(t, "email", clientResponse["field"])
 
 	// Verify audit log was sent to Kafka
+	assert.True(t, mock.WaitForSend(time.Second), "Producer should have been called within 1s")
 	assert.True(t, mock.Called(), "Producer should have been called")
 
 	eventJson, ok := mock.Value().(sdkmodels.EventJson)
@@ -325,6 +330,7 @@ func TestAuditMiddleware_ServerError_CapturesResponseBody(t *testing.T) {
 	e.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.True(t, mock.WaitForSend(time.Second), "Producer should have been called within 1s")
 
 	eventJson := mock.Value().(sdkmodels.EventJson)
 	payloadPtr, ok := eventJson.Payload.(*map[string]any)

--- a/middleware/authentication.go
+++ b/middleware/authentication.go
@@ -147,10 +147,7 @@ func AuthenticationMiddleware(cfg interfaces.Config, logger interfaces.Logger, p
 				},
 			}
 
-			kafkaErr := producer.Send(c.Request().Context(), topic, event)
-			if kafkaErr != nil {
-				logger.Error(c.Request().Context(), "Failed to send %s event to Kafka topic '%s' for event ID %s: %v", "login.success", topic, event.Id.String(), kafkaErr)
-			}
+			sendEventAsync(producer, logger, topic, event, "login.success")
 			return true, nil
 		},
 		ErrorHandler: func(handlerErr error, c echo.Context) error {
@@ -177,10 +174,7 @@ func AuthenticationMiddleware(cfg interfaces.Config, logger interfaces.Logger, p
 				},
 			}
 
-			kafkaErr := producer.Send(c.Request().Context(), topic, event)
-			if kafkaErr != nil {
-				logger.Error(c.Request().Context(), "Failed to send %s event to Kafka topic '%s' for event ID %s: %v", "login.failure", topic, event.Id.String(), kafkaErr)
-			}
+			sendEventAsync(producer, logger, topic, event, "login.failure")
 
 			return echo.ErrUnauthorized
 		},

--- a/middleware/authorization.go
+++ b/middleware/authorization.go
@@ -192,10 +192,7 @@ func errorHandler(
 		},
 	}
 
-	kafkaErr := producer.Send(ctx, topic, event)
-	if kafkaErr != nil {
-		logger.Error(ctx, "Failed to send %s event to Kafka topic '%s' for event ID %s: %v", eventType, topic, event.Id.String(), kafkaErr)
-	}
+	sendEventAsync(producer, logger, topic, event, eventType)
 
 	switch status_code {
 	// Allow consumers to handle bad gateway errors gracefully

--- a/middleware/kafka.go
+++ b/middleware/kafka.go
@@ -1,0 +1,23 @@
+package middleware
+
+import (
+	"context"
+	"time"
+
+	sdkmodels "github.com/grasp-labs/ds-event-stream-go-sdk/models"
+	"github.com/grasp-labs/ds-go-echo-middleware/v2/middleware/adapters"
+	"github.com/grasp-labs/ds-go-echo-middleware/v2/middleware/interfaces"
+)
+
+// sendEventAsync fires a Kafka event in a detached goroutine so it never
+// blocks the HTTP response. A 5-second timeout ensures the goroutine exits
+// cleanly if Kafka is unavailable.
+func sendEventAsync(producer *adapters.ProducerAdapter, logger interfaces.Logger, topic string, event sdkmodels.EventJson, eventType string) {
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := producer.Send(ctx, topic, event); err != nil {
+			logger.Error(ctx, "Failed to send %s event: %v", eventType, err)
+		}
+	}()
+}

--- a/middleware/usage.go
+++ b/middleware/usage.go
@@ -79,10 +79,7 @@ func UsageMiddleware(cfg interfaces.Config, logger interfaces.Logger, producer *
 				},
 			}
 
-			kafkaErr := producer.Send(c.Request().Context(), topic, event)
-			if kafkaErr != nil {
-				logger.Error(c.Request().Context(), "Failed to send usage event to Kafka topic '%s' for event ID %s: %v", topic, event.Id.String(), kafkaErr)
-			}
+			sendEventAsync(producer, logger, topic, event, "usage.report")
 
 			return callErr
 		}

--- a/middleware/usage_test.go
+++ b/middleware/usage_test.go
@@ -73,6 +73,7 @@ func TestUsageMiddleware_BasicFlow(t *testing.T) {
 
 	// Assertions
 	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, mock.WaitForSend(time.Second), "Producer should have been called within 1s")
 	assert.True(t, mock.Called(), "Producer should have been called")
 	assert.NotEmpty(t, mock.Key(), "Usage key should be set")
 


### PR DESCRIPTION
## Summary

- Wrap all `producer.Send` calls in a detached goroutine with a `context.Background()` + 5s timeout so the HTTP handler returns immediately instead of blocking on Kafka
- Extract the shared fire-and-forget pattern into `middleware/kafka.go` (`sendEventAsync`)
- Make `MockProducer` thread-safe (mutex on fields) and add `WaitForSend(timeout)` so tests can synchronise on the async call without races

## Test plan

- [ ] `go test ./middleware/... -race -count=1` passes clean
- [ ] Verify HTTP responses are no longer delayed when Kafka is slow or down